### PR TITLE
Check whether __has_include is defined before using it

### DIFF
--- a/bcc/module.go
+++ b/bcc/module.go
@@ -32,10 +32,14 @@ import (
 // #include <dlfcn.h>
 // #include <stdbool.h>
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 //

--- a/bcc/perf.go
+++ b/bcc/perf.go
@@ -26,10 +26,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 // #include <bcc/perf_reader.h>

--- a/bcc/sym.c
+++ b/bcc/sym.c
@@ -15,10 +15,14 @@
 #include "_cgo_export.h"
 #include <stdio.h>
 #include <stdbool.h>
-#if __has_include(<bcc/bcc_common.h>)
-  #include <bcc/bcc_common.h>
+#ifdef __has_include
+  #if __has_include(<bcc/bcc_common.h>)
+    #include <bcc/bcc_common.h>
+  #else
+    #include <bcc/bpf_common.h>
+  #endif
 #else
-  #include <bcc/bpf_common.h>
+  #include <bcc/bcc_common.h>
 #endif
 #include <bcc/libbpf.h>
 #include <dlfcn.h>
@@ -138,7 +142,7 @@ int init_symlookup(void *handle) {
     symlookup[BPF_TABLE_NAME                 ] = dlsym(handle, "bpf_table_name");
     symlookup[BPF_UPDATE_ELEM                ] = dlsym(handle, "bpf_update_elem");
     symlookup[PERF_READER_FD                 ] = dlsym(handle, "perf_reader_fd");
-    symlookup[PERF_READER_POLL               ] = dlsym(handle, "perf_reader_poll");                    
+    symlookup[PERF_READER_POLL               ] = dlsym(handle, "perf_reader_poll");
 
     // Make sure all symbols were resolvable.
     int i;

--- a/bcc/symbol.go
+++ b/bcc/symbol.go
@@ -24,10 +24,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 // #include <bcc/bcc_syms.h>

--- a/bcc/table.go
+++ b/bcc/table.go
@@ -25,10 +25,14 @@ import (
 // #cgo CFLAGS: -I/usr/include/bcc/compat
 // #cgo LDFLAGS: -ldl
 //
-// #if __has_include(<bcc/bcc_common.h>)
-//   #include <bcc/bcc_common.h>
+// #ifdef __has_include
+//   #if __has_include(<bcc/bcc_common.h>)
+//     #include <bcc/bcc_common.h>
+//   #else
+//     #include <bcc/bpf_common.h>
+//   #endif
 // #else
-//   #include <bcc/bpf_common.h>
+//   #include <bcc/bcc_common.h>
 // #endif
 // #include <bcc/libbpf.h>
 //


### PR DESCRIPTION
This PR modifies `gobpf` to check whether the preprocessor supports `__has_include` before trying to use it.

`__has_include` was introduced in GCC 7.2 and without this fix, trying to build Teleport with BPF support on an older version of glibc fails. This is necessary to build Teleport on CentOS 7 as per [this comment](https://github.com/gravitational/teleport/issues/4754#issuecomment-749587441).

```console
---> Building OSS binaries.
/usr/bin/make build/teleport build/tctl build/tsh
make[2]: Entering directory `/go/src/github.com/gravitational/teleport'
GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build -tags "pam  bpf" -o build/teleport -ldflags -w -ldflags '-w -s' ./tool/teleport
# github.com/iovisor/gobpf/bcc
vendor/github.com/iovisor/gobpf/bcc/module.go:35:20: error: missing binary operator before token "("
 // #if __has_include (<bcc/bcc_common.h>)
                    ^
vendor/github.com/iovisor/gobpf/bcc/module.go:38:31: fatal error: bcc/bpf_common.h: No such file or directory
 //   #include <bcc/bpf_common.h>
                               ^
compilation terminated.
make[2]: *** [build/teleport] Error 2
make[1]: *** [all] Error 2
make: *** [release] Error 2
make[2]: Leaving directory `/go/src/github.com/gravitational/teleport'
make: *** [Makefile:219: release] Error 2
make: Leaving directory '/home/gus/go/src/github.com/gravitational/teleport/build.assets'
```

The idea here is that if the GCC being used supports `__has_include`, everything should work the same as it does currently. If GCC doesn't have support, it will fall back to including `bcc/bcc_common.h` which is the [default path from the upstream module](https://github.com/iovisor/gobpf/blob/master/bcc/module.go#L32).

Tested with the current `ubuntu:18.04` buildbox as well as my `centos:7` changes.